### PR TITLE
coding exam finished [27DDK8399]

### DIFF
--- a/src/q1/solve.spec.ts
+++ b/src/q1/solve.spec.ts
@@ -9,7 +9,7 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C1] ハッピーパス（基本価格の確認）
   // ------------------------------
-  it.skip('[C1] Adult/Young/Child の価格が正しく出る', () => {
+  it('[C1] Adult/Young/Child の価格が正しく出る', () => {
     const a = solve('Adult,G,10:00,1:00,A-1');
     const y = solve('Young,G,10:00,1:00,A-2');
     const c = solve('Child,G,10:00,1:00,I-3');
@@ -18,7 +18,7 @@ describe('Q1 solve', () => {
     expect(c).toBe('800円');
   });
 
-  it.skip('[C1] 全部OKの複数枚購入で価格が行ごとに出る', () => {
+  it('[C1] 全部OKの複数枚購入で価格が行ごとに出る', () => {
     const input = [
       'Adult,G,10:00,1:00,A-1',
       'Young,G,10:00,1:00,A-2',
@@ -31,19 +31,19 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C2] レーティング規則（年齢制限）
   // ------------------------------
-  it.skip('[C2] R18+ を Young/Child で購入不可 → 年齢制限', () => {
+  it('[C2] R18+ を Young/Child で購入不可 → 年齢制限', () => {
     const y = solve('Young,R18+,10:00,1:00,A-1');
     const c = solve('Child,R18+,10:00,1:00,I-2');
     expect(y).toBe('対象の映画は年齢制限により閲覧できません');
     expect(c).toBe('対象の映画は年齢制限により閲覧できません');
   });
 
-  it.skip('[C2] PG-12 を Child 単独で購入不可（Adult 同時購入なし）', () => {
+  it('[C2] PG-12 を Child 単独で購入不可（Adult 同時購入なし）', () => {
     const out = solve('Child,PG-12,10:00,1:00,I-1');
     expect(out).toBe('対象の映画は年齢制限により閲覧できません');
   });
 
-  it.skip('[C2] PG-12 を Adult + Child 同時購入 → 両方購入可', () => {
+  it('[C2] PG-12 を Adult + Child 同時購入 → 両方購入可', () => {
     const input = [
       'Adult,PG-12,10:00,1:00,A-1',
       'Child,PG-12,10:00,1:00,I-2',
@@ -55,7 +55,7 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C3] 座席規則（J〜L × Child）
   // ------------------------------
-  it.skip('[C3] Child の I 行は購入可 / J 行は購入不可 / L 行は購入不可', () => {
+  it('[C3] Child の I 行は購入可 / J 行は購入不可 / L 行は購入不可', () => {
     const ok = solve('Child,G,10:00,1:00,I-1');
     const j = solve('Child,G,10:00,1:00,J-1');
     const l = solve('Child,G,10:00,1:00,L-24');
@@ -67,14 +67,14 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C4] 時刻規則（境界含む、Adult なし）
   // ------------------------------
-  it.skip('[C4] Child: 終了16:00ちょうどは可 / 16:01は同伴必要', () => {
+  it('[C4] Child: 終了16:00ちょうどは可 / 16:01は同伴必要', () => {
     const ok = solve('Child,G,15:00,1:00,I-1'); // end=16:00
     const ng = solve('Child,G,15:01,1:00,I-2'); // end=16:01
     expect(ok).toBe('800円');
     expect(ng).toBe('対象の映画の入場には大人の同伴が必要です');
   });
 
-  it.skip('[C4] Young: 終了18:00ちょうどは可 / 18:01は同伴必要', () => {
+  it('[C4] Young: 終了18:00ちょうどは可 / 18:01は同伴必要', () => {
     const ok = solve('Young,G,17:00,1:00,A-1'); // end=18:00
     const ng = solve('Young,G,17:01,1:00,A-2'); // end=18:01
     expect(ok).toBe('1200円');
@@ -84,7 +84,7 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C5] グループ規則（Adult 不在で Child を含む）
   // ------------------------------
-  it.skip('[C5] Adult なし + Young & Child / 終了16:01超 → 両方 同伴必要 で全体不可', () => {
+  it('[C5] Adult なし + Young & Child / 終了16:01超 → 両方 同伴必要 で全体不可', () => {
     const input = [
       'Young,G,15:30,1:00,A-1', // end=16:30
       'Child,G,15:30,1:00,I-2', // end=16:30
@@ -99,7 +99,7 @@ describe('Q1 solve', () => {
     );
   });
 
-  it.skip('[C5] Adult を1枚追加で Young/Child とも購入可（同伴必要が消える）', () => {
+  it('[C5] Adult を1枚追加で Young/Child とも購入可（同伴必要が消える）', () => {
     const input = [
       'Adult,G,15:30,1:00,A-3',
       'Young,G,15:30,1:00,A-1',
@@ -112,7 +112,7 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C6] 複合理由・順序・重複排除
   // ------------------------------
-  it.skip('[C6] Child + PG-12 + J席 + Adultなし + 終了16:01 → 理由3つ（順序固定）', () => {
+  it('[C6] Child + PG-12 + J席 + Adultなし + 終了16:01 → 理由3つ（順序固定）', () => {
     const out = solve('Child,PG-12,15:30,1:00,J-10'); // end=16:30
     // 順序：同伴必要 → 年齢制限 → 座席制限
     expect(out).toBe(
@@ -124,7 +124,7 @@ describe('Q1 solve', () => {
     );
   });
 
-  it.skip('[C6] PG-12 Child 単独（安全席・早い時刻）→ 年齢制限のみ', () => {
+  it('[C6] PG-12 Child 単独（安全席・早い時刻）→ 年齢制限のみ', () => {
     const out = solve('Child,PG-12,10:00,1:00,I-1');
     expect(out).toBe('対象の映画は年齢制限により閲覧できません');
   });
@@ -132,7 +132,7 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C7] 全体不可の出力仕様（価格を出さない）
   // ------------------------------
-  it.skip('[C7] 1枚OK/1枚NG の混在 → NG行の理由だけを出力', () => {
+  it('[C7] 1枚OK/1枚NG の混在 → NG行の理由だけを出力', () => {
     const input = [
       'Adult,G,10:00,1:00,A-1', // OK
       'Child,G,10:00,1:00,J-16', // 座席NG
@@ -141,7 +141,7 @@ describe('Q1 solve', () => {
     expect(out).toBe('対象のチケットではその座席をご利用いただけません');
   });
 
-  it.skip('[C7] 全部NGなら全NG理由行が並ぶ（入力順）', () => {
+  it('[C7] 全部NGなら全NG理由行が並ぶ（入力順）', () => {
     const input = [
       'Child,R18+,10:00,1:00,J-1', // 年齢 + 座席
       'Young,R18+,10:00,1:00,A-2', // 年齢
@@ -159,7 +159,7 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C8] 不正入力（フォーマット・範囲外）
   // ------------------------------
-  it.skip('[C8] 未知の区分/レーティング/座席形式/カラム数不正 → 不正な入力です', () => {
+  it('[C8] 未知の区分/レーティング/座席形式/カラム数不正 → 不正な入力です', () => {
     const cases = [
       'Senior,G,10:00,1:00,A-1', // 未知の年齢
       'Adult,PG12,10:00,1:00,A-1', // 未知のレーティング
@@ -173,5 +173,26 @@ describe('Q1 solve', () => {
     for (const bad of cases) {
       expect(solve(bad)).toBe('不正な入力です');
     }
+  });
+
+  // ------------------------------
+  // [C9] 補足ケース（漏れチェック）
+  // ------------------------------
+  it('[C9] Young の PG-12 単独OK, Adult の R18+ OK, Child の A席OK, 長時間上映OK', () => {
+    // Young 単独 PG-12 は許可
+    const y = solve('Young,PG-12,10:00,1:00,A-1');
+    expect(y).toBe('1200円');
+
+    // Adult 単独 R18+ は許可
+    const a = solve('Adult,R18+,10:00,1:00,B-2');
+    expect(a).toBe('1800円');
+
+    // Child が A列は利用可
+    const c = solve('Child,G,10:00,1:00,A-3');
+    expect(c).toBe('800円');
+
+    // 長時間上映 (2時間30分) のパース確認
+    const long = solve('Adult,G,10:00,2:30,C-4');
+    expect(long).toBe('1800円');
   });
 });

--- a/src/q1/solve.ts
+++ b/src/q1/solve.ts
@@ -17,6 +17,7 @@ export type Ticket = {
 const PRICE: Record<Age, number> = { Adult: 1800, Young: 1200, Child: 800 };
 
 // 出力メッセージ（テストと同一文字列に揃える）
+// 課題指定の文言そのまま。表示順は「同伴必要 → 年齢制限 → 座席制限」
 const MSG = {
   NEED_ADULT: '対象の映画の入場には大人の同伴が必要です',
   AGE_LIMIT: '対象の映画は年齢制限により閲覧できません',
@@ -41,26 +42,31 @@ export const solve = (input: string): string => {
     .map((s) => s.trim())
     .filter(Boolean);
 
-  // smoke 用：空入力は空出力（テスト配線確認）
+  // 空入力なら空文字を返す（配線確認用）
   if (lines.length === 0) return '';
 
-  // 入力をパース（不正なら即終了）
+  // パースに失敗したら「不正な入力です」で即時終了（簡略仕様）
   const tickets: Ticket[] = [];
   for (const line of lines) {
     const t = parseLine(line);
-    if (!t) return '不正な入力です'; // TODO: 必要に応じて詳細化してもよい（仕様は1行固定でOK）
+    if (!t) return '不正な入力です';
     tickets.push(t);
   }
 
-  // セット属性（同一上映前提）
+  // 同時購入は同一作品前提。代表として先頭チケットの rating / 終了時刻を用いる。
   const hasAdult = tickets.some((t) => t.age === 'Adult');
   const hasChild = tickets.some((t) => t.age === 'Child'); // C5 で使用（グループ規則）
   const rating = tickets[0].rating;
   const endMinutes = calcEndMinutes(tickets[0]); // 今年は日跨ぎなし前提
 
   // 各行の評価
-  const evaluated: { ok: boolean; text: string }[] = [];
+  const evaluated: { ok: boolean; text: string; reasons: string[] }[] = [];
   let anyNg = false;
+
+  // 全体理由の有無を集計するためのフラグ
+  let trigNeedAdult = false;
+  let trigAgeLimit = false;
+  let trigSeatLimit = false;
 
   for (const t of tickets) {
     const reasons: string[] = [];
@@ -68,26 +74,40 @@ export const solve = (input: string): string => {
     // 理由の push 順は README の順序に合わせておく（後で orderReasons で厳密化）
     if (!checkTimeRule(t, endMinutes, hasAdult, hasChild)) {
       reasons.push(MSG.NEED_ADULT);
+      trigNeedAdult = true;
     }
     if (!checkRating(t.age, rating, hasAdult)) {
       reasons.push(MSG.AGE_LIMIT);
+      trigAgeLimit = true;
     }
     if (!checkSeat(t)) {
       reasons.push(MSG.SEAT_LIMIT);
+      trigSeatLimit = true;
     }
 
-    const ordered = orderReasons(reasons); // TODO: 並び替えを実装
+    const ordered = orderReasons(reasons);
 
     if (ordered.length === 0) {
-      evaluated.push({ ok: true, text: `${PRICE[t.age]}円` });
+      evaluated.push({ ok: true, text: `${PRICE[t.age]}円`, reasons: [] });
     } else {
       anyNg = true;
-      evaluated.push({ ok: false, text: uniqueStable(ordered).join(',') });
+      evaluated.push({
+        ok: false,
+        text: uniqueStable(ordered).join(','),
+        reasons: uniqueStable(ordered),
+      });
     }
   }
 
-  // TODO 「全体不可」のときは価格を出さず、NG行の理由だけを出力する
+  // 「全体不可」のときは価格を出さず、NG行の理由だけを出力する
+  if (anyNg) {
+    return evaluated
+      .filter((e) => !e.ok)
+      .map((e) => e.text)
+      .join('\n');
+  }
 
+  // 全て OK の場合は、各行の価格をそのまま出力
   return evaluated.map((e) => e.text).join('\n');
 };
 
@@ -97,6 +117,8 @@ export const solve = (input: string): string => {
  *  - startHH/startMM/durH/durM の範囲チェック（例: 23:59, 分は 0-59）
  *  - 座席の列番号 1-24 の範囲チェック
  *  - その他フォーマットの揺れ（必要なら）
+ *
+ * 雛形の方針に合わせ、最小限の検証のみを行う。
  */
 const parseLine = (line: string): Ticket | null => {
   const parts = line.split(',').map((s) => s.trim());
@@ -119,6 +141,13 @@ const parseLine = (line: string): Ticket | null => {
   const row = seat[1].toUpperCase();
   const col = parseInt(seat[2], 10);
 
+  // 数値レンジ検証（雛形の TODO を実装）
+  if (startHH < 0 || startHH > 23) return null;
+  if (startMM < 0 || startMM > 59) return null;
+  if (durH < 0) return null;
+  if (durM < 0 || durM > 59) return null;
+  if (col < 1 || col > 24) return null;
+
   return {
     age: ageRaw as Age,
     rating: ratingRaw as Rating,
@@ -131,6 +160,7 @@ const parseLine = (line: string): Ticket | null => {
   };
 };
 
+// 終了時刻（分）＝開始分＋上映時間（分）／今年は日跨ぎなし前提。
 const calcEndMinutes = (t: Ticket): number => {
   const start = t.startHH * 60 + t.startMM;
   const end = start + t.durH * 60 + t.durM;
@@ -142,22 +172,37 @@ const calcEndMinutes = (t: Ticket): number => {
  *  - G: 誰でも可
  *  - PG-12: Child は Adult 同時購入がなければ不可
  *  - R18+: Adult 以外は不可
+ *
+ * README のまま実装。
  */
 const checkRating = (
   age: Age,
   rating: Rating,
   hasAdultInSet: boolean
 ): boolean => {
-  // TODO ここを実装
+  if (rating === 'G') return true;
+  if (rating === 'PG-12') {
+    // Child 単独（= 同時購入に Adult がいない）なら NG
+    if (age === 'Child' && !hasAdultInSet) return false;
+    return true;
+  }
+  // R18+ は Adult のみ可
+  if (rating === 'R18+') {
+    return age === 'Adult';
+  }
   return true;
 };
 
 /**
  * 座席の規則
  *  - J〜L は Child 不可
+ *
+ * Child が J/K/L 行なら NG。
  */
 const checkSeat = (t: Ticket): boolean => {
-  // TODO ここを実装
+  if (t.age !== 'Child') return true;
+  const r = t.row.toUpperCase();
+  if (r === 'J' || r === 'K' || r === 'L') return false;
   return true;
 };
 
@@ -167,6 +212,8 @@ const checkSeat = (t: Ticket): boolean => {
  *  - Adult が 0 かつ Child を含み、終了が 16:00 を超える → Young も含め全員 NG
  *  - Adult が 0 で Young 単独など、終了が 18:00 を超える Young は NG
  *  - ちょうど 16:00/18:00 は OK
+ *
+ * endMinutes は代表（先頭チケット）から算出。今回は日跨ぎなし前提。
  */
 const checkTimeRule = (
   t: Ticket,
@@ -174,19 +221,40 @@ const checkTimeRule = (
   hasAdultInSet: boolean,
   hasChildInSet: boolean
 ): boolean => {
-  // TODO ここを実装
-  return true;
+  if (hasAdultInSet) return true; // Adult 同伴がいれば常に OK
+
+  // Adult がいない場合のみ、以下を検査
+  const END_16 = 16 * 60;
+  const END_18 = 18 * 60;
+
+  if (hasChildInSet) {
+    // 子供を含み、終了が 16:00 を超えると NG（16:00 ちょうどは OK）
+    if (endMinutes > END_16) return false;
+    return true;
+  } else {
+    // Young のみ等の場合、終了が 18:00 を超えると NG（18:00 ちょうどは OK）
+    if (endMinutes > END_18) return false;
+    return true;
+  }
 };
 
 /**
  * 理由の順序を安定化（README: 「同伴 → 年齢 → 座席」）
+ * 表示順固定のため、既知の3種類のみ並べ替える。
  */
 const orderReasons = (reasons: string[]): string[] => {
-  // TODO ここを実装
-  return reasons;
+  const hasNeed = reasons.includes(MSG.NEED_ADULT);
+  const hasAge = reasons.includes(MSG.AGE_LIMIT);
+  const hasSeat = reasons.includes(MSG.SEAT_LIMIT);
+  const out: string[] = [];
+  if (hasNeed) out.push(MSG.NEED_ADULT);
+  if (hasAge) out.push(MSG.AGE_LIMIT);
+  if (hasSeat) out.push(MSG.SEAT_LIMIT);
+  return out;
 };
 
 // 重複排除（stable）
+// 先に出たものを残し、後続の重複を捨てる。
 const uniqueStable = <T>(arr: T[]): T[] => {
   const seen = new Set<T>();
   const out: T[] = [];

--- a/src/q2/core.spec.ts
+++ b/src/q2/core.spec.ts
@@ -1,14 +1,107 @@
-import { describe, expect, it } from 'vitest';
-import { parseLines } from './core.js';
+/* eslint-disable max-lines-per-function */
+import { describe, it, expect } from 'vitest';
+import { aggregate } from './core.js';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
-describe('Q2 core', () => {
-  it('parseLines: skips broken rows', () => {
-    const rows = parseLines([
-      '2025-01-03T10:12:00Z,u1,/a,200,100',
-      'broken,row,only,three',
+// ヘルパ: 一時CSV作成
+async function writeCsv(lines: string[]): Promise<string> {
+  const file = path.join(os.tmpdir(), `q2_${Date.now()}_${Math.random()}.csv`);
+  await fs.writeFile(file, lines.join('\n'), 'utf8');
+  return file;
+}
+
+describe('Q2 aggregate – README要件', () => {
+  it('[Parse] 壊れた行はスキップ（欠損/非数）', async () => {
+    const csv = await writeCsv([
+      'timestamp,userId,path,status,latencyMs',
+      '2025-01-03T10:12:00Z,u1,/api/a,200,100',
+      'badline',                                           // 壊れた行
+      '2025-01-03T10:12:00Z,u2,/api/a,xxx,120',           // status 非数 → スキップ
+      '2025-01-03T10:12:00Z,u3,/api/a,200,NaN',           // latency 非数 → スキップ
     ]);
-    expect(rows.length).toBe(1);
+    const out = await aggregate({ filePath: csv, tz: 'jst', from: '2025-01-01', to: '2025-01-31' });
+    expect(out).toEqual([
+      { date: '2025-01-03', path: '/api/a', count: 1, avgLatency: 100 }
+    ]);
   });
 
-  it.todo('aggregate basic');
+  it('[Range] from/to はUTC基準・両端含む', async () => {
+    // UTCの範囲 [2025-01-01T00:00Z, 2025-01-31T23:59:59Z] に入る2件を用意。
+    // JSTに変換すると 1/1 と 2/1 に分かれるが、集計は「date×path」なので
+    // 1行にまとまらず、/api/a の合計 count が 2 であることを検証する。
+    const csv = await writeCsv([
+      'timestamp,userId,path,status,latencyMs',
+      '2025-01-01T00:00:00Z,u1,/api/a,200,100',  // = from
+      '2025-01-31T23:59:59Z,u2,/api/a,200,200',  // = to (UTC内)
+      '2025-02-01T00:00:00Z,u3,/api/a,200,300',  // 範囲外
+    ]);
+    const out = await aggregate({ filePath: csv, tz: 'jst', from: '2025-01-01', to: '2025-01-31' });
+    // 修正点: 1行で count=2 を期待せず、「/api/a の行の合計 count が 2」であることを確認
+    const total = out
+      .filter(r => r.path === '/api/a')
+      .reduce((n, r) => n + r.count, 0);
+    expect(total).toBe(2);
+  });
+
+  it('[TZ] UTC→JST/ICT の日付変換で日付跨ぎが合う', async () => {
+    // 異なる path を使い、JST/ICT での日付を個別に検証する。
+    const csv = await writeCsv([
+      'timestamp,userId,path,status,latencyMs',
+      '2025-01-01T15:30:00Z,u1,/api/a,200,100', // JST=+9 → 2025-01-02
+      '2025-01-01T00:30:00Z,u2,/api/b,200,100', // ICT=+7 → 2025-01-01
+    ]);
+    const jst = await aggregate({ filePath: csv, tz: 'jst' });
+    const ict = await aggregate({ filePath: csv, tz: 'ict' });
+    expect(jst.find(r => r.path === '/api/a')!.date).toBe('2025-01-02'); // 15:30Z +9h → 翌日
+    expect(ict.find(r => r.path === '/api/b')!.date).toBe('2025-01-01'); // 00:30Z +7h → 同日
+  });
+
+  it('[Group] date×path 集計・平均は四捨五入', async () => {
+    const csv = await writeCsv([
+      'timestamp,userId,path,status,latencyMs',
+      '2025-01-03T10:00:00Z,u1,/api/a,200,100',
+      '2025-01-03T11:00:00Z,u2,/api/a,200,101', // avg=100.5 → 101
+      '2025-01-03T12:00:00Z,u3,/api/b,200,300',
+    ]);
+    const out = await aggregate({ filePath: csv, tz: 'jst' });
+    expect(out).toContainEqual({ date: '2025-01-03', path: '/api/a', count: 2, avgLatency: 101 });
+    expect(out).toContainEqual({ date: '2025-01-03', path: '/api/b', count: 1, avgLatency: 300 });
+  });
+
+  it('[TopN] 上位Nは「日付ごと」・count降順・同数はpath昇順', async () => {
+    const csv = await writeCsv([
+      'timestamp,userId,path,status,latencyMs',
+      '2025-01-03T00:00:00Z,u, /a,200,100',
+      '2025-01-03T01:00:00Z,u, /a,200,100',
+      '2025-01-03T02:00:00Z,u, /b,200,100',
+      '2025-01-04T00:00:00Z,u, /c,200,100',
+      '2025-01-04T01:00:00Z,u, /d,200,100',
+      '2025-01-04T02:00:00Z,u, /d,200,100',
+    ].map(s => s.replace(' ', ''))); // quick fix before write
+    const out = await aggregate({ filePath: csv, tz: 'jst', top: 1 });
+    // 2025-01-03 → /a (count=2) , 2025-01-04 → /d (count=2)
+    expect(out).toEqual([
+      { date: '2025-01-03', path: '/a', count: 2, avgLatency: 100 },
+      { date: '2025-01-04', path: '/d', count: 2, avgLatency: 100 },
+    ]);
+  });
+
+  it('[Final Sort] date↑ → count↓ → path↑', async () => {
+    const csv = await writeCsv([
+      'timestamp,userId,path,status,latencyMs',
+      '2025-01-02T00:00:00Z,u1,/b,200,100', // date 1/2
+      '2025-01-02T01:00:00Z,u2,/a,200,100', // same date, same count=1 → path ASC
+      '2025-01-01T00:00:00Z,u3,/z,200,100', // date 1/1 comes first
+      '2025-01-02T02:00:00Z,u4,/b,200,100', // makes /b count=2 -> before /a
+    ]);
+    const out = await aggregate({ filePath: csv, tz: 'jst' });
+    expect(out.map(r => `${r.date}:${r.path}:${r.count}`)).toEqual([
+      '2025-01-01:/z:1',
+      '2025-01-02:/b:2',
+      '2025-01-02:/a:1',
+    ]);
+  });
 });
+/* eslint-enable max-lines-per-function */

--- a/src/q2/core.ts
+++ b/src/q2/core.ts
@@ -1,108 +1,183 @@
-type TZ = 'jst' | 'ict';
+// ==============================
+// Q2: アクセスログ集計（コアロジック）
+// ------------------------------
+// READMEの仕様に厳密に従い実装。入力CSVはUTC、期間フィルタはUTC起点（両端含む）。
+// 集計結果は tz（jst/ict）適用後の日付で date×path 集約。avgLatency は四捨五入整数。
+// 上位Nは「日付ごと」に count 降順（同数は path 昇順）。最終出力は
+// date 昇順 → count 降順 → path 昇順の決定的順序。
 
-export type Row = {
-  timestamp: string; // ISO8601 UTC
-  userId: string;
-  path: string;
-  status: number;
-  latencyMs: number;
-};
+import * as fs from 'node:fs';
+import * as readline from 'node:readline';
+
+export type Tz = 'jst' | 'ict';
 
 export type Options = {
-  from: string; // YYYY-MM-DD (UTC 起点)
-  to: string; // YYYY-MM-DD (UTC 起点)
-  tz: TZ;
-  top: number;
+  filePath: string;              // CSV file path
+  from?: string;                 // 'YYYY-MM-DD' in UTC (inclusive)
+  to?: string;                   // 'YYYY-MM-DD' in UTC (inclusive)
+  tz: Tz;                        // 'jst' (UTC+9) | 'ict' (UTC+7)
+  top?: number;                  // top N per date (optional; if unset -> all)
 };
 
-export type Output = Array<{
-  date: string; // tz での YYYY-MM-DD
-  path: string;
-  count: number;
-  avgLatency: number;
-}>;
-
-export const aggregate = (lines: string[], opt: Options): Output => {
-  const rows = parseLines(lines);
-  const filtered = filterByDate(rows, opt.from, opt.to);
-  const grouped = groupByDatePath(filtered, opt.tz);
-  const ranked = rankTop(grouped, opt.top);
-  return ranked;
+export type OutputRow = {
+  date: string;                  // YYYY-MM-DD after tz applied
+  path: string;                  // e.g. /api/orders
+  count: number;                 // occurrences per date×path
+  avgLatency: number;            // rounded average latency (四捨五入)
 };
 
-export const parseLines = (lines: string[]): Row[] => {
-  const out: Row[] = [];
-  for (const line of lines) {
-    const [timestamp, userId, path, status, latencyMs] = line.split(',');
-    if (!timestamp || !userId || !path || !status || !latencyMs) continue; // 壊れ行はスキップ
-    out.push({
-      timestamp: timestamp.trim(),
-      userId: userId.trim(),
-      path: path.trim(),
-      status: Number(status),
-      latencyMs: Number(latencyMs),
-    });
+// 期間フィルタの境界をUTCで作る（両端含む）
+function makeUtcRange(from?: string, to?: string): { lo: number; hi: number } {
+  const MIN = -8.64e15; // Date最小 ~ -275760-09-01
+  const MAX =  8.64e15; // Date最大 ~ 275760-09-13
+
+  const lo = from ? Date.parse(`${from}T00:00:00.000Z`) : MIN;
+  const hi = to   ? Date.parse(`${to}T23:59:59.999Z`)   : MAX;
+
+  return { lo, hi };
+}
+
+// tz適用後の「日付(YYYY-MM-DD)」を厳密に生成（UTCゲッターで手組み）
+function toTzDateString(utcMs: number, tz: Tz): string {
+  const offsetHours = tz === 'jst' ? 9 : 7;
+  const shifted = new Date(utcMs + offsetHours * 60 * 60 * 1000);
+
+  const y = shifted.getUTCFullYear();
+  const m = shifted.getUTCMonth() + 1; // 0-based
+  const d = shifted.getUTCDate();
+
+  const mm = m < 10 ? `0${m}` : String(m);
+  const dd = d < 10 ? `0${d}` : String(d);
+  return `${y}-${mm}-${dd}`;
+}
+
+// CSV 1行をパース。壊れていれば null を返す（README: 壊れた行はスキップ）。
+function parseCsvLine(line: string):
+  | { tsMs: number; path: string; latency: number }
+  | null {
+  const parts = line.split(',');
+  if (parts.length !== 5) return null;
+
+  // _uid は未使用なので省略（lint対応）
+  const [tsRaw, , pathRaw, statusRaw, latRaw] = parts;
+
+  // timestamp (UTC)
+  const ts = Date.parse(tsRaw);
+  if (!Number.isFinite(ts)) return null;
+
+  // status: 数値として妥当か簡易チェック（使わないが壊れ行除外のため）
+  const status = Number(statusRaw);
+  if (!Number.isFinite(status)) return null;
+
+  // latency 必須
+  const latency = Number(latRaw);
+  if (!Number.isFinite(latency)) return null;
+
+  // path: trim後に空ならNG
+  const path = (pathRaw ?? '').trim();
+  if (!path) return null;
+
+  return { tsMs: ts, path, latency };
+}
+
+// ===== 追加: parseLines を公開 =====
+/**
+ * 複数行のCSV文字列を受け取り、壊れた行をスキップして配列を返すヘルパー。
+ * ヘッダ処理はしない（与えられた行だけを対象にする）。
+ */
+export function parseLines(
+  lines: string[]
+): Array<{ tsMs: number; path: string; latency: number }> {
+  const out: Array<{ tsMs: number; path: string; latency: number }> = [];
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    const rec = parseCsvLine(line); // 内部の行パーサ
+    if (rec) out.push(rec);         // 壊れた行は無視
   }
   return out;
-};
+}
 
-const filterByDate = (rows: Row[], from: string, to: string): Row[] => {
-  const fromT = Date.parse(from + 'T00:00:00Z');
-  const toT = Date.parse(to + 'T23:59:59Z');
-  return rows.filter((r) => {
-    const t = Date.parse(r.timestamp);
-    return t >= fromT && t <= toT;
-  });
-};
+// 1行ずつ読みながら、期間フィルタ→TZ日付→date×path 集計。
+export async function aggregate(opts: Options): Promise<OutputRow[]> {
+  const { filePath, from, to, tz, top } = opts;
+  const { lo, hi } = makeUtcRange(from, to);
 
-const toTZDate = (utcIso: string, tz: TZ): string => {
-  const t = new Date(utcIso);
-  const offsetHours = tz === 'jst' ? 9 : 7; // JST=UTC+9, ICT=UTC+7
-  const local = new Date(t.getTime() + offsetHours * 60 * 60 * 1000);
-  const y = local.getUTCFullYear();
-  const m = (local.getUTCMonth() + 1).toString().padStart(2, '0');
-  const d = local.getUTCDate().toString().padStart(2, '0');
-  return `${y}-${m}-${d}`;
-};
+  const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
-const groupByDatePath = (rows: Row[], tz: TZ) => {
-  const map = new Map<string, { sum: number; cnt: number }>();
+  // date|path → { count, sumLatency }
+  const agg = new Map<string, { count: number; sumLatency: number }>();
+
+  let isFirst = true;
+
+  for await (const raw of rl) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    // ヘッダ行をスキップ（先頭1行だけ厳密に判定）
+    if (isFirst) {
+      isFirst = false;
+      if (/^timestamp,userId,path,status,latencyMs$/i.test(line)) {
+        continue;
+      }
+    }
+
+    const rec = parseCsvLine(line);
+    if (!rec) continue; // 壊れた行はスキップ
+
+    // 期間フィルタ（UTC, 両端含む）
+    if (rec.tsMs < lo || rec.tsMs > hi) continue;
+
+    // tz適用後の日付
+    const dateStr = toTzDateString(rec.tsMs, tz);
+
+    const key = `${dateStr}|${rec.path}`;
+    const cur = agg.get(key);
+    if (cur) {
+      cur.count += 1;
+      cur.sumLatency += rec.latency;
+    } else {
+      agg.set(key, { count: 1, sumLatency: rec.latency });
+    }
+  }
+
+  // Map → 配列化し、avgLatency を四捨五入で算出
+  const rows: OutputRow[] = [];
+  for (const [key, val] of agg.entries()) {
+    const [date, path] = key.split('|');
+    const avg = Math.round(val.sumLatency / val.count);
+    rows.push({ date, path, count: val.count, avgLatency: avg });
+  }
+
+  // 日付ごとに TopN 抽出（count ↓, path ↑）
+  const byDate = new Map<string, OutputRow[]>();
   for (const r of rows) {
-    const date = toTZDate(r.timestamp, tz);
-    const key = `${date}\u0000${r.path}`;
-    const cur = map.get(key) || { sum: 0, cnt: 0 };
-    cur.sum += r.latencyMs;
-    cur.cnt += 1;
-    map.set(key, cur);
+    const list = byDate.get(r.date) ?? [];
+    list.push(r);
+    byDate.set(r.date, list);
   }
-  return Array.from(map.entries()).map(([k, v]) => {
-    const [date, path] = k.split('\u0000');
-    return { date, path, count: v.cnt, avgLatency: Math.round(v.sum / v.cnt) };
-  });
-};
 
-const rankTop = (
-  items: { date: string; path: string; count: number; avgLatency: number }[],
-  top: number
-) => {
-  // 日付ごとに件数順で上位N
-  const byDate = new Map<string, typeof items>();
-  for (const it of items) {
-    const arr = byDate.get(it.date) || [];
-    arr.push(it);
-    byDate.set(it.date, arr);
+  const topK = typeof top === 'number' && top > 0 ? top : Infinity;
+  const sliced: OutputRow[] = [];
+
+  // lint対応: 未使用変数を避けるため values() を用いる
+  for (const list of byDate.values()) {
+    list.sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;         // count DESC
+      if (a.path !== b.path) return a.path.localeCompare(b.path); // path ASC
+      return 0;
+    });
+    const take = list.slice(0, Math.min(list.length, topK));
+    sliced.push(...take);
   }
-  const out: typeof items = [];
-  for (const [, arr] of byDate) {
-    arr.sort((a, b) => b.count - a.count || a.path.localeCompare(b.path));
-    out.push(...arr.slice(0, top));
-  }
-  // 安定した出力順: date ASC, count DESC
-  out.sort(
-    (a, b) =>
-      a.date.localeCompare(b.date) ||
-      b.count - a.count ||
-      a.path.localeCompare(b.path)
-  );
-  return out;
-};
+
+  // 最終並び順 = date ↑ → count ↓ → path ↑（README）
+  sliced.sort((a, b) => {
+    if (a.date !== b.date) return a.date.localeCompare(b.date);   // date ASC
+    if (b.count !== a.count) return b.count - a.count;            // count DESC
+    return a.path.localeCompare(b.path);                          // path ASC
+  });
+
+  return sliced;
+}


### PR DESCRIPTION
## Summary
Completed both Q1 and Q2 according to the specification.

### Q1
- Implemented all ticket rules (rating / seat / companion by end time)
- Set-level NG output logic (only NG reasons per NG ticket)
- Fixed reason order: 同伴必要 → 年齢制限 → 座席制限

### Q2
- UTC range inclusive (from 00:00Z to 23:59:59.999Z)
- TZ conversion for JST (+9) and ICT (+7)
- Grouped by date×path, avgLatency rounded (四捨五入)
- Per-day TopN (count desc, tie by path asc)
- Final sort: date ↑ → count ↓ → path ↑
- CLI argument parser (--file --from --to --tz --top)
- parseLines & broken row skip implemented
- All tests passed (`pnpm test`), typecheck & lint OK
